### PR TITLE
AP-17 Inclusão de regra para visualização de evento reopened

### DIFF
--- a/source/web/app/components/dashboard/tasks/events/activity/activity-autofill-event.component.html
+++ b/source/web/app/components/dashboard/tasks/events/activity/activity-autofill-event.component.html
@@ -7,15 +7,21 @@
       <mat-card-title>{{data.acronym}}-{{data.name}}</mat-card-title>
       <mat-card-subtitle>Criado em: {{data.date | date : "dd/MM/yyy HH:mm"}}</mat-card-subtitle>
     </div>
-    <button *ngIf="translatedStatus[data.status].translation !== 'Realizado'" mat-fab class="mat-mini-fab" matTooltip="Preencher atividade"
-            aria-label="Preencher atividade" on-click="callPreview()" [disabled]="data.status !== 'PENDING'">
+    <button *ngIf="data.status === 'PENDING'" mat-fab class="mat-mini-fab" matTooltip="Preencher atividade"
+            aria-label="Preencher atividade" on-click="callPreview()" [disabled]="data.status === 'ACCOMPLISHED'">
       <mat-icon>play_arrow</mat-icon>
     </button>
 
-    <button *ngIf= 'translatedStatus[data.status].translation === "Realizado"' mat-fab class="mat-mini-fab" matTooltip="atividade preenchida"
+    <button *ngIf="data.status === 'REOPENED'" mat-fab class="mat-mini-fab" matTooltip="Repreencher atividade"
+            aria-label="Repreencher atividade" on-click="callPreview()" [disabled]="data.status === 'ACCOMPLISHED'">
+      <mat-icon>play_arrow</mat-icon>
+    </button>
+
+    <button *ngIf= "data.status === 'ACCOMPLISHED'" mat-fab class="mat-mini-fab" matTooltip="atividade preenchida"
             aria-label="atividade prenchida" readonly="true" disabled>
       <mat-icon>checked</mat-icon>
     </button>
+
   </mat-card-header>
   <mat-card-content>
     <p fxFlex="80" fxLayoutAlign="start center">


### PR DESCRIPTION
Debug e estudo para ver o porque os eventos de atividade reopened não eram visualizados na tela. (falta de regra nova no outcomes)